### PR TITLE
Remove references of 'dev' branch

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -3,7 +3,7 @@ on:
   workflow_run:
     workflows: [CI Build]
     types: [completed]
-    branches: [main, dev]
+    branches: [main]
 jobs:
   publish-snapshot:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MapRoulette Java Client
 
-![GitHub Action CI Build](https://github.com/maproulette/maproulette-java-client/actions/workflows/pull-request.yml/badge.svg?branch=dev)
+![GitHub Action CI Build](https://github.com/maproulette/maproulette-java-client/actions/workflows/pull-request.yml/badge.svg?branch=main)
 ![Sonatype Nexus (Releases)](https://img.shields.io/nexus/r/org.maproulette.client/maproulette-java-client?server=https%3A%2F%2Foss.sonatype.org)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group=org.maproulette.client
 
 # When making changes to the version, keep the trailing '-SNAPSHOT' for automation purposes.
-# Snapshot builds will be published automatically for new commits to the main and dev branches.
+# Snapshot builds will be published automatically for new commits to the main branch.
 #
 # If you want to publish a release, create a GitHub Release using the UI.
 # This will trigger a build that removes the '-SNAPSHOT' suffix and publishes the release to Sonatype.


### PR DESCRIPTION
Going forward the `main` branch will be used for PRs and set as the default branch, and the `dev` branch is now set as read only. This change is being made to further simplify the development and deployment processes and take advantage of existing GitHub Actions.