### PR TITLE
Update slf4j-api, junit, mockito

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,10 +22,10 @@ ext {
     depHttpVersion = "4.5.1"
     depJacksonVersion = "2.9.8"
     depJacocoVersion = "0.8.3"
-    depJunitVersion = "5.5.2"
+    depJunitVersion = "5.9.2"
     depLombokVersion = "1.18.10"
-    depMockitoVersion = "2.23.0"
-    depSlf4jVersion = "1.7.12"
+    depMockitoVersion = "5.2.0"
+    depSlf4jVersion = "2.0.7"
 }
 
 apply from: 'gradle/quality.gradle'


### PR DESCRIPTION
Update a few outdated dependencies. The only runtime dep is 'slf4j-api' and it should be backwards compatible for users of the library.

- Impl:
  - Sfl4j 1.7.12 to 2.0.7
- Test:
  - Junit 5.5.2 to 5.9.2
  - Mockito 2.23.0 to 5.2.0

