### PR TITLE
Include challenge preferredTags and preferredReviewTags to tests

### DIFF
--- a/src/integrationTest/java/org/maproulette/client/api/ChallengeAPIIntegrationTest.java
+++ b/src/integrationTest/java/org/maproulette/client/api/ChallengeAPIIntegrationTest.java
@@ -195,6 +195,9 @@ public class ChallengeAPIIntegrationTest extends IntegrationBase
         Assertions.assertEquals(challenge1.getDefaultBasemap(), challenge2.getDefaultBasemap());
         Assertions.assertEquals(challenge1.getDefaultBasemapId(), challenge2.getDefaultBasemapId());
         Assertions.assertEquals(challenge1.getCustomBasemap(), challenge2.getCustomBasemap());
+        Assertions.assertEquals(challenge1.getPreferredTags(), challenge2.getPreferredTags());
+        Assertions.assertEquals(challenge1.getPreferredReviewTags(),
+                challenge2.getPreferredReviewTags());
     }
 
     private Challenge getBasicChallenge()

--- a/src/test/java/org/maproulette/client/serializer/ChallengeSerializationTest.java
+++ b/src/test/java/org/maproulette/client/serializer/ChallengeSerializationTest.java
@@ -38,6 +38,7 @@ public class ChallengeSerializationTest
                 .customBasemap("customBaseMap").defaultBasemap(23)
                 .defaultBasemapId("defaultBaseMap").defaultPriority(ChallengePriority.LOW)
                 .defaultZoom(17).difficulty(ChallengeDifficulty.EXPERT).enabled(true).featured(true)
+                .preferredTags("#tag1,#tag2").preferredReviewTags("#reviewTag1,#reviewTag2")
                 .id(1234L).maxZoom(2).minZoom(3).build();
 
         final var serializedString = this.mapper.writeValueAsString(full);
@@ -64,6 +65,9 @@ public class ChallengeSerializationTest
         Assertions.assertEquals(full.getMaxZoom(), deserializedChallenge.getMaxZoom());
         Assertions.assertEquals(full.getMinZoom(), deserializedChallenge.getMinZoom());
         Assertions.assertEquals(full.getParent(), deserializedChallenge.getParent());
+        Assertions.assertEquals(full.getPreferredTags(), deserializedChallenge.getPreferredTags());
+        Assertions.assertEquals(full.getPreferredReviewTags(),
+                deserializedChallenge.getPreferredReviewTags());
     }
 
     @Test
@@ -177,6 +181,9 @@ public class ChallengeSerializationTest
         Assertions.assertNotNull(deserializedChallenge.getMediumPriorityRule());
         Assertions.assertEquals(mediumPriority, deserializedChallenge.getMediumPriorityRule());
         Assertions.assertEquals(lowPriority, deserializedChallenge.getLowPriorityRule());
+        Assertions.assertEquals("#tag1,#tag2", deserializedChallenge.getPreferredTags());
+        Assertions.assertEquals("#reviewTag1,#reviewTag2",
+                deserializedChallenge.getPreferredReviewTags());
     }
 
     /**

--- a/src/test/resources/challenges/testChallenge.json
+++ b/src/test/resources/challenges/testChallenge.json
@@ -34,5 +34,7 @@
         ]
       }
     ]
-  }
+  },
+  "preferredTags": "#tag1,#tag2",
+  "preferredReviewTags": "#reviewTag1,#reviewTag2"
 }


### PR DESCRIPTION
### Description:

The `Challenge` tests did not check for consistency of fields `preferredTags` and `preferredReviewTags`. This minor patch includes thoses tests.

### Unit Test Approach:

Included the two missing checks on fields preferredTags and preferredReviewTags.

### Test Results:

Successful tests and it's validated during the GH Action build.
