### PR TITLE
Use version=0.4.5-SNAPSHOT in gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ group=org.maproulette.client
 #
 # If you want to publish a release, create a GitHub Release using the UI.
 # This will trigger a build that removes the '-SNAPSHOT' suffix and publishes the release to Sonatype.
-version=0.4.4-SNAPSHOT
+version=0.4.5-SNAPSHOT
 
 project_name=MapRoulette Java Client
 project_description=Java Client to connect and use MapRoulette API


### PR DESCRIPTION
### Description:

Update the version to `0.4.5-SNAPSHOT` to prepare for a new production release. There are no functional changes for the published artifact. However, a few CICD (GitHub Actions) updates were done along with test/testdependency updates.
