### PR TITLE
Fix ProjectAPIIntegrationTests and add it to CI

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -79,7 +79,8 @@ jobs:
           ./gradlew --info --project-prop runIntegrationTests \
             integrationTest \
             --tests '*BatchUploaderIntegrationTest*' \
-            --tests '*ChallengeAPIIntegrationTest*'
+            --tests '*ChallengeAPIIntegrationTest*' \
+            --tests '*ProjectAPIIntegrationTest*'
 
   validation:
     name: "Gradle Validation"

--- a/gradle/quality.gradle
+++ b/gradle/quality.gradle
@@ -51,6 +51,17 @@ task integrationTest(type: Test) {
         events "passed", "skipped", "failed"
         exceptionFormat = 'full'
     }
+    beforeTest { descriptor ->
+        logger.lifecycle("Running integration test: " + descriptor)
+    }
+    afterSuite { desc, result ->
+        if (!desc.parent) { // will match the outermost suite
+            def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
+            def startItem = '|  ', endItem = '  |'
+            def repeatLength = startItem.length() + output.length() + endItem.length()
+            println('\n' + ('-' * repeatLength) + '\n' + startItem + output + endItem + '\n' + ('-' * repeatLength))
+        }
+    }
 }
 
 check.dependsOn integrationTest

--- a/src/integrationTest/java/org/maproulette/client/IntegrationBase.java
+++ b/src/integrationTest/java/org/maproulette/client/IntegrationBase.java
@@ -88,7 +88,8 @@ public class IntegrationBase
         if (this.configuration == null)
         {
             this.configurationParamsSetUp();
-            this.configuration = new MapRouletteConfiguration(this.host, this.port, this.apiKey);
+            this.configuration = new MapRouletteConfiguration(this.scheme, this.host, this.port,
+                    this.apiKey);
         }
         return this.configuration;
     }

--- a/src/integrationTest/java/org/maproulette/client/api/ProjectAPIIntegrationTest.java
+++ b/src/integrationTest/java/org/maproulette/client/api/ProjectAPIIntegrationTest.java
@@ -26,6 +26,7 @@ public class ProjectAPIIntegrationTest extends IntegrationBase
         final var projectIdentifier = this.getProjectAPIForNewConfiguration().create(project)
                 .getId();
         Assertions.assertNotEquals(-1, projectIdentifier);
+        Assertions.assertTrue(this.getProjectAPI().forceDelete(projectIdentifier));
     }
 
     @Test
@@ -111,6 +112,7 @@ public class ProjectAPIIntegrationTest extends IntegrationBase
         Assertions.assertEquals(numberOfChildren, challenges.size());
         challenges.forEach(
                 challenge -> Assertions.assertTrue(challengeList.contains(challenge.getId())));
+        Assertions.assertTrue(this.getProjectAPI().forceDelete(parentIdentifier));
     }
 
     private void compare(final Project project1, final Project project2)


### PR DESCRIPTION
### Description:

Fixed the connection issue in the project integration tests by supporing the 'scheme'.
Added cleanup steps to remove lingering projects after successful tests in ProjectAPIIntegrationTest.
Also edited `quality.gradle` to print out the tests that are running.

### Unit Test Approach:

This repairs the test and updates it to run during CI.

### Test Results:

CI build log shows it's running:

    Running integration test: Test findTest()(org.maproulette.client.api.ProjectAPIIntegrationTest)
