### PR TITLE
Fix the Task Api Integration tests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -80,7 +80,8 @@ jobs:
             integrationTest \
             --tests '*BatchUploaderIntegrationTest*' \
             --tests '*ChallengeAPIIntegrationTest*' \
-            --tests '*ProjectAPIIntegrationTest*'
+            --tests '*ProjectAPIIntegrationTest*' \
+            --tests '*TaskAPIIntegrationTest*'
 
   validation:
     name: "Gradle Validation"

--- a/src/integrationTest/java/org/maproulette/client/api/TaskAPIIntegrationTest.java
+++ b/src/integrationTest/java/org/maproulette/client/api/TaskAPIIntegrationTest.java
@@ -100,7 +100,7 @@ public class TaskAPIIntegrationTest extends IntegrationBase
                 .get(updatedTask.getId());
         Assertions.assertTrue(retrievedUpdatedTask.isPresent());
 
-        Assertions.assertEquals("{\"features\":["
+        Assertions.assertEquals("{\"type\":\"FeatureCollection\",\"features\":["
                 + String.format(TestConstants.FEATURE_STRING, 3.1, 4.2, UPDATED_GEOMETRY) + "]}",
                 retrievedUpdatedTask.get().getGeometries().toString());
     }
@@ -134,7 +134,7 @@ public class TaskAPIIntegrationTest extends IntegrationBase
         this.compare(updatedTask, retrievedUpdatedTask.get());
         Assertions
                 .assertEquals(
-                        "{\"features\":["
+                        "{\"type\":\"FeatureCollection\",\"features\":["
                                 + String.format(
                                         TestConstants.FEATURE_STRING, 1.1, 2.2, DEFAULT_GEOMETRY)
                                 + ","
@@ -151,7 +151,8 @@ public class TaskAPIIntegrationTest extends IntegrationBase
         Assertions.assertEquals(ChallengePriority.HIGH, task2.getPriority());
         Assertions.assertEquals(task1.getParent(), task2.getParent());
         Assertions.assertEquals(task1.getInstruction(), task2.getInstruction());
-        Assertions.assertEquals(task1.getGeometries(), task2.getGeometries());
+        Assertions.assertEquals(task1.getGeometries().get("features"),
+                task2.getGeometries().get("features"));
     }
 
     private Task getDefaultTask(final String name)


### PR DESCRIPTION
The integration tests related to tasks were broken. It's fixed. The GH Action is producing output, 
```
Running integration test: Test updateTest()(org.maproulette.client.api.TaskAPIIntegrationTest)
00:17:46.114 INFO  [4dadca42-3c92-4e4c-a764-a5e587fc395b][application-akka.actor.default-dispatcher-10][AccessLogger] - Request 'POST /api/v2/challenge' [org.maproulette.controllers.api.ChallengeController.create] 10ms - Response 201
00:17:46.133 INFO  [b9b8abae-adde-4cdd-a327-838fde43b7cd][application-akka.actor.default-dispatcher-15][AccessLogger] - Request 'POST /api/v2/challenge' [org.maproulette.controllers.api.ChallengeController.create] 9ms - Response 201
00:17:46.143 INFO  [09d3828a-5015-40bc-9908-006933d83550][application-akka.actor.default-dispatcher-15][AccessLogger] - Request 'GET /ping' [controllers.Application.ping] 1ms - Response 200
00:17:46.168 INFO  [f58a7924-5e88-47a5-8b20-62dd4e91bdb6][application-akka.actor.default-dispatcher-6][AccessLogger] - Request 'POST /api/v2/task' [org.maproulette.controllers.api.TaskController.create] 16ms - Response 201
00:17:46.182 INFO  [546fbc3e-7d56-4134-ac8d-ccab64ce30e6][application-akka.actor.default-dispatcher-10][AccessLogger] - Request 'GET /api/v2/task/6' [org.maproulette.controllers.api.TaskController.read] 4ms - Response 200
```